### PR TITLE
fix: disabled NPM cache for CI

### DIFF
--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -19,20 +19,8 @@ jobs:
       - name: "Checkout source code"
         uses: actions/checkout@v2
 
-      # Cache node_modules to speed up the process
-      - name: "Restore node_modules cache"
-        id: cache-npm
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: npm6-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm6-${{ env.cache-name }}-
-            npm6-
-
       # Install npm dependencies for Prettier and Jest
       - name: "Install npm dependencies"
-        if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci && npm run ci:postinstall
 
       # Prettier formatting

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,20 +19,8 @@ jobs:
       - name: "Checkout source code"
         uses: actions/checkout@v2
 
-      # Cache node_modules to speed up the process
-      - name: "Restore node_modules cache"
-        id: cache-npm
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: npm6-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm6-${{ env.cache-name }}-
-            npm6-
-
       # Install npm dependencies for Prettier and Jest
       - name: "Install npm dependencies"
-        if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci && npm run ci:postinstall
 
       # Prettier formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,8 @@ jobs:
       - name: "Checkout source code"
         uses: actions/checkout@v2
 
-      # Cache node_modules to speed up the process
-      - name: "Restore node_modules cache"
-        id: cache-npm
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: npm6-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm6-${{ env.cache-name }}-
-            npm6-
-
       # Install npm dependencies for Prettier and Jest
       - name: "Install npm dependencies"
-        if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci && npm run ci:postinstall
 
       # Prettier formatting


### PR DESCRIPTION
Disabling NPM cache for CI to prevent issues with functions dependencies.