### PR TITLE
build: align engine versions and use volta inheritance

### DIFF
--- a/functions/01_Intro_ProcessLargeData_JS/package-lock.json
+++ b/functions/01_Intro_ProcessLargeData_JS/package-lock.json
@@ -15,7 +15,7 @@
         "sinon": "^14.0.1"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/functions/01_Intro_ProcessLargeData_JS/package.json
+++ b/functions/01_Intro_ProcessLargeData_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha"
@@ -22,5 +19,11 @@
     "eslint": "^8.28.0",
     "mocha": "^10.0.0",
     "sinon": "^14.0.1"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/02_InvocationEvent_JS/package-lock.json
+++ b/functions/02_InvocationEvent_JS/package-lock.json
@@ -15,7 +15,7 @@
         "sinon": "^14.0.1"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/functions/02_InvocationEvent_JS/package.json
+++ b/functions/02_InvocationEvent_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha"
@@ -22,5 +19,11 @@
     "eslint": "^8.28.0",
     "mocha": "^10.0.0",
     "sinon": "^14.0.1"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/03_Context_DataApiQuery_JS/package-lock.json
+++ b/functions/03_Context_DataApiQuery_JS/package-lock.json
@@ -14,7 +14,7 @@
         "sinon": "^14.0.1"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/functions/03_Context_DataApiQuery_JS/package.json
+++ b/functions/03_Context_DataApiQuery_JS/package.json
@@ -9,9 +9,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha"
@@ -21,5 +18,11 @@
     "eslint": "^8.28.0",
     "mocha": "^10.0.0",
     "sinon": "^14.0.1"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/03_Context_OrgInfo_TypeScript/package-lock.json
+++ b/functions/03_Context_OrgInfo_TypeScript/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "^4.8.2"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/functions/03_Context_OrgInfo_TypeScript/package.json
+++ b/functions/03_Context_OrgInfo_TypeScript/package.json
@@ -9,9 +9,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "build": "tsc",
     "lint": "eslint . --ext .ts",
@@ -33,5 +30,11 @@
     "sinon": "^14.0.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.2"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/03_Context_SalesforceSDK_JS/package-lock.json
+++ b/functions/03_Context_SalesforceSDK_JS/package-lock.json
@@ -15,7 +15,7 @@
         "sinon": "^13.0.2"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/functions/03_Context_SalesforceSDK_JS/package.json
+++ b/functions/03_Context_SalesforceSDK_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha"
@@ -22,5 +19,11 @@
     "eslint": "^8.28.0",
     "mocha": "^10.1.0",
     "sinon": "^13.0.2"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/03_Context_UnitOfWork_JS/package-lock.json
+++ b/functions/03_Context_UnitOfWork_JS/package-lock.json
@@ -15,7 +15,7 @@
         "sinon": "^14.0.1"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/functions/03_Context_UnitOfWork_JS/package.json
+++ b/functions/03_Context_UnitOfWork_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha"
@@ -22,5 +19,11 @@
     "eslint": "^8.28.0",
     "mocha": "^10.0.0",
     "sinon": "^14.0.1"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/04_Logger_JS/package-lock.json
+++ b/functions/04_Logger_JS/package-lock.json
@@ -15,7 +15,7 @@
         "sinon": "^14.0.1"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/functions/04_Logger_JS/package.json
+++ b/functions/04_Logger_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha"
@@ -22,5 +19,11 @@
     "eslint": "^8.28.0",
     "mocha": "^10.0.0",
     "sinon": "^14.0.1"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/05_Environment_JS/package-lock.json
+++ b/functions/05_Environment_JS/package-lock.json
@@ -15,7 +15,7 @@
         "sinon": "^14.0.1"
       },
       "engines": {
-        "node": "^16.0"
+        "node": "^16.18"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/functions/05_Environment_JS/package.json
+++ b/functions/05_Environment_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.0"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha"
@@ -22,5 +19,11 @@
     "eslint": "^8.28.0",
     "mocha": "^10.0.0",
     "sinon": "^14.0.1"
+  },
+  "engines": {
+    "node": "^16.18"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/06_Data_Postgres_JS/package.json
+++ b/functions/06_Data_Postgres_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.9"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha --loader=quibble"
@@ -28,5 +25,11 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "pg": "^8.8.0"
+  },
+  "engines": {
+    "node": "^16.9"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/functions/06_Data_Redis_JS/package.json
+++ b/functions/06_Data_Redis_JS/package.json
@@ -10,9 +10,6 @@
   "repository": {
     "type": "git"
   },
-  "engines": {
-    "node": "^16.9"
-  },
   "scripts": {
     "lint": "eslint . --ext .js",
     "test": "mocha --loader=quibble"
@@ -28,5 +25,11 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "redis": "^4.4.0"
+  },
+  "engines": {
+    "node": "^16.9"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12272,10 +12272,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -15498,12 +15501,6 @@
       "bin": {
         "json5": "lib/cli.js"
       }
-    },
-    "node_modules/tsconfig-paths/node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
@@ -25852,9 +25849,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "minimist-options": {
@@ -28268,12 +28265,6 @@
           "requires": {
             "minimist": "^1.2.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-          "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",


### PR DESCRIPTION
Aligns all function projects to use node `^16.18` and introduced volta inheritance to map versions with root `package.json`:
```
"volta": {
    "extends": "../../../package.json"
}
```