### PR TITLE
fix: use default Functions permset description

### DIFF
--- a/force-app/main/default/permissionsets/Functions.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Functions.permissionset-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>Functions Recipes - Object Permissions</description>
+    <description>Permissions for Salesforce Functions to access Salesforce org data</description>
     <fieldPermissions>
         <editable>true</editable>
         <field>Account.AccountNumber</field>


### PR DESCRIPTION
### What does this PR do?
Changes the description on the Functions permission set so that it matches the one that was generated automatically when the Functions license was applied. I feel the original wording is better so as to not risk users thinking the permission set is only relevant to Functions Recipes use cases.
