### PR TITLE
Fix Java distance formula in function 01

### DIFF
--- a/functions/01_Intro_ProcessLargeData_JS/test/index.test.js
+++ b/functions/01_Intro_ProcessLargeData_JS/test/index.test.js
@@ -38,6 +38,7 @@ describe("Unit Tests", () => {
     expect(results).to.be.not.undefined;
     expect(results.schools).to.be.an("array");
     expect(results.schools.length).to.be.eql(payload.length);
+    expect(results.schools[0].distance).to.be.closeTo(0.235389, 0.000001);
   });
 
   it("Invoke ProcessLargeData with missing coordinates", async () => {

--- a/functions/01_Intro_ProcessLargeData_Java/src/main/java/com/salesforce/functions/recipes/ProcessLargeDataFunction.java
+++ b/functions/01_Intro_ProcessLargeData_Java/src/main/java/com/salesforce/functions/recipes/ProcessLargeDataFunction.java
@@ -82,6 +82,7 @@ public class ProcessLargeDataFunction implements SalesforceFunction<FunctionInpu
       }
       dist = Math.acos(dist);
       dist = (dist * 180) / Math.PI;
+      dist = dist * 60 * 1.1515;
       return dist;
     }
   }

--- a/functions/01_Intro_ProcessLargeData_Java/src/test/java/com/salesforce/functions/recipes/FunctionTest.java
+++ b/functions/01_Intro_ProcessLargeData_Java/src/test/java/com/salesforce/functions/recipes/FunctionTest.java
@@ -17,6 +17,7 @@ public class FunctionTest {
     int length = eventMock.getData().getLength();
     FunctionOutput functionOutput = function.apply(eventMock, createContextMock());
     assertEquals(functionOutput.getSchools().size(), length);
+    assertEquals(0.235389, functionOutput.getSchools().get(0).getDistance(), 0.000001);
   }
 
   @Test


### PR DESCRIPTION
The current implementations of the distance method between the Java and JavaScript versions of function 01_Intro_ProcessLargeData are currently calculating vastly different distances with the same inputs.

The JavaScript version of the function is more accurate based on a Google Maps comparison.

* Modify the distance method in the Java function to calculate the distance the same way as the JavaScript distance method.
* Add assertions about the accuracy of the distance to the tests for both the JavaScript and Java tests that have non-empty payloads.

Fixes #707 01_Intro_ProcessLargeData_Java does not calculate distance correctly

### What does this PR do?
Modify the Java `distance()` method to match the JavaScript version

### What issues does this PR fix or reference?
#707 01_Intro_ProcessLargeData_Java does not calculate distance correctly
#<Insert GitHub Issue>

## The PR fulfills these requirements:

[*] Tests for the proposed changes have been added/updated.
[*] Code linting and formatting was performed.

### Functionality Before
```java
distance(36.169090, -115.140579, 36.1657, -115.141);
// => 0.003406994620636472
```
### Functionality After
```java
distance(36.169090, -115.140579, 36.1657, -115.141);
// => 0.23538925833977384
```
